### PR TITLE
FPS-7 - Даунгрейд до старой версии библиотеки работы с дисплеем

### DIFF
--- a/src/OLED/OLED.cpp
+++ b/src/OLED/OLED.cpp
@@ -1,40 +1,39 @@
-#include <Arduino.h>
 #include "OLED.h"
 
+
 OLED::OLED()
-  : _u8g2(U8G2_R0, /* reset=*/ U8X8_PIN_NONE)
+  : _u8g(U8GLIB_SSD1306_128X64(U8G_I2C_OPT_NONE | U8G_I2C_OPT_DEV_0))	// I2C / TWI 
 {
 }
 
 bool OLED::init()
 {
-  if(!_u8g2.begin())
+  if(!_u8g.begin())
     return false;
   
-  _u8g2.setPowerSave(0);
-  _u8g2.setFont(u8g_font_6x10);
-  _u8g2.setFontRefHeightExtendedText();
-  _u8g2.setFontPosTop();
+  _u8g.setFont(u8g_font_6x10);
+  _u8g.setFontRefHeightExtendedText();
+  _u8g.setFontPosTop();
   return true;
 }
 
 void OLED::printInitializeScreen()
 {
-  _u8g2.firstPage();
+  _u8g.firstPage();
   do  
   {
     //NOTE: Без setFont не работает!
-    _u8g2.setColorIndex(1);
-    _u8g2.setFont(u8g_font_6x13);
-    _u8g2.drawStr(40, DEBUG_TEXT_STRING_3, "LOADING...");
+    _u8g.setColorIndex(1);
+    _u8g.setFont(u8g_font_6x13);
+    _u8g.drawStr(40, DEBUG_TEXT_STRING_3, "LOADING...");
   } 
-  while( _u8g2.nextPage() );
+  while( _u8g.nextPage() );
 }
 
 void OLED::printAllData(const SensorsData &data)
 {
   // picture loop  
-  _u8g2.firstPage();  
+  _u8g.firstPage();  
   do 
   {
     String temperatureStr = "Temp:  " + (isnan(data.temperature)? "nan" : String(data.temperature)) + " C";
@@ -42,11 +41,11 @@ void OLED::printAllData(const SensorsData &data)
     String luxStr = "Lux:   " + String(data.lux) + " lx";
     String darkStr = "Is dark: " + String(data.isDark? "+" : "-");
 
-    _u8g2.setFont(DEBUG_TEXT_FONT);
-    _u8g2.drawStr(0, DEBUG_TEXT_STRING_0, temperatureStr.c_str());
-    _u8g2.drawStr(0, DEBUG_TEXT_STRING_1, humidityStr.c_str());
-    _u8g2.drawStr(0, DEBUG_TEXT_STRING_2, luxStr.c_str());
-    _u8g2.drawStr(0, DEBUG_TEXT_STRING_3, darkStr.c_str());
+    _u8g.setFont(DEBUG_TEXT_FONT);
+    _u8g.drawStr(0, DEBUG_TEXT_STRING_0, temperatureStr.c_str());
+    _u8g.drawStr(0, DEBUG_TEXT_STRING_1, humidityStr.c_str());
+    _u8g.drawStr(0, DEBUG_TEXT_STRING_2, luxStr.c_str());
+    _u8g.drawStr(0, DEBUG_TEXT_STRING_3, darkStr.c_str());
   } 
-  while( _u8g2.nextPage() );
+  while( _u8g.nextPage() );
 }

--- a/src/OLED/OLED.h
+++ b/src/OLED/OLED.h
@@ -1,15 +1,16 @@
 #pragma once
 
-#include <U8g2lib.h>
+#include <Arduino.h>
+#include <U8glib.h>
 #include "../Sensors/SensorData.h"
 
 // SSD1306 OLED DEBUG PRINT
-#define DEBUG_TEXT_STRING_0 00
-#define DEBUG_TEXT_STRING_1 10
-#define DEBUG_TEXT_STRING_2 20
-#define DEBUG_TEXT_STRING_3 30
-#define DEBUG_TEXT_STRING_4 40
-#define DEBUG_TEXT_STRING_5 50
+#define DEBUG_TEXT_STRING_0 10
+#define DEBUG_TEXT_STRING_1 20
+#define DEBUG_TEXT_STRING_2 30
+#define DEBUG_TEXT_STRING_3 40
+#define DEBUG_TEXT_STRING_4 50
+#define DEBUG_TEXT_STRING_5 60
 #define DEBUG_TEXT_FONT u8g_font_6x10
 //
 
@@ -32,5 +33,5 @@ class OLED
     private:
         /// @brief Экземпляр дисплея U8G2 для SSD1306 с разрешением 128x64, без маркировки, с использованием аппаратного I2C.
         /// @note Если динамической памяти будет не хватать, можно заменить U8G2_SSD1306_128X64_NONAME_1_HW_I2C
-        U8G2_SSD1306_128X64_NONAME_2_HW_I2C _u8g2;
+        U8GLIB_SSD1306_128X64 _u8g;
 };


### PR DESCRIPTION
Этот PR включает существенные изменения в обработке OLED-дисплея в классе `OLED`, переход с библиотеки `U8g2lib` на библиотеку `U8glib`. Наиболее важные изменения включают обновление методов инициализации и отображения, изменение файла заголовка для отражения новой библиотеки и корректировку позиций отладочного текста.

Изменения в обработке OLED-дисплея:

* [`src/OLED/OLED.cpp`](diffhunk://#diff-3cf02bd274ea412cb012bbb9a84145dd8474a4c4e6ce77ed96c34c8ce349e185L1-R50): Заменено использование `_u8g2` на `_u8g` для перехода с `U8g2lib` на `U8glib`, обновлены такие методы, как `init()`, `printInitializeScreen()` и `printAllData()`.

Настройки заголовочного файла:

* [`src/OLED/OLED.h`](diffhunk://#diff-c6fa63df54876998ce583bd57d7d6bdc486484736e9a3702c7dc4c9d8d601f04L3-R13): Заменено `#include <U8g2lib.h>` на `#include <U8glib.h>` и скорректированы позиции отладочного текста путем увеличения каждой позиции на 10 единиц.

Обновление члена класса:

* [`src/OLED/OLED.h`](diffhunk://#diff-c6fa63df54876998ce583bd57d7d6bdc486484736e9a3702c7dc4c9d8d601f04L35-R36): Изменен закрытый член с `U8G2_SSD1306_128X64_NONAME_2_HW_I2C _u8g2` на `U8GLIB_SSD1306_128X64 _u8g`, чтобы отразить новое использование библиотеки.